### PR TITLE
Additional parameters for guacamole_connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ OPTIONS (= is mandatory):
         [Default: (null)]
         type: str
 
-- sftp_private_key_password
+- sftp_passphrase
         Password for the sftp private key used for authentication
         [Default: (null)]
         type: str

--- a/plugins/modules/guacamole_connection.py
+++ b/plugins/modules/guacamole_connection.py
@@ -395,7 +395,7 @@ def main():
         sftp_hostname=dict(type='str', required=False),
         sftp_username=dict(type='str', required=False),
         sftp_password=dict(type='str', required=False, no_log=True),
-        sftp_private_key=dict(type='str', required=False),
+        sftp_private_key=dict(type='str', required=False, no_log=True),
         sftp_private_key_password=dict(type='str', required=False, no_log=True),
         sftp_root_directory=dict(type='str', required=False),
         sftp_default_upload_directory=dict(type='str', required=False)


### PR DESCRIPTION
Hi,
I'm adding a bunch of parameters and  disabling logging of the SFTP private key (which might not always be encrypted).

I have a few reservations:
* I noticed that you have already added the `passphrase` parameter for SFTP keys. Does it mean that this parameter applies to both `private-key` and `sftp-private-key`? If not, `sftp_private_key_password` should map to the APi's `sftp-passphrase` parameter and I will create a new parameter for this module which applies to the SSH connection.
* I have not prefixed my parameters with `ssh` or `rdp`, I can change that if you feel this makes sense.