### PR TITLE
Improve connections listing

### DIFF
--- a/devel-utils/docker-compose.yml
+++ b/devel-utils/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   init-guac-db:
     image: guacamole/guacamole:latest
     user: root
-    command: ["/bin/sh", "-c", "test -e /init/initdb.sql && echo 'init file already exists' || /opt/guacamole/bin/initdb.sh --postgres > /init/initdb.sql" ]
+    command: ["/bin/sh", "-c", "test -e /init/initdb.sql && echo 'init file already exists' || /opt/guacamole/bin/initdb.sh --postgresql > /init/initdb.sql" ]
     volumes:
       - dbinit:/init
 

--- a/plugins/inventory/README.md
+++ b/plugins/inventory/README.md
@@ -1,6 +1,6 @@
 # scicore.guacamole.guacamole_inventory – Apache Guacamole dynamic inventory plugin
 
-Wait would you say about getting all your connections details from Apache Guacamole and parsing them to ansible as inventory ? It would be amazing, right ? 
+What would you say about getting all your connections details from Apache Guacamole and passing them to Ansible as inventory ? It would be amazing, right ? 
 
 Guess what, You are in the right place. It's all about this plugin.
 
@@ -15,7 +15,7 @@ Guess what, You are in the right place. It's all about this plugin.
 
 ## Synopsis
 
-- Get connection details from Apache Guacamole API and parse them to ansible as inventory.
+- Get connection details from Apache Guacamole API and pass them to ansible as inventory.
 - Uses an YAML configuration file ending with either `guacamole.yml` or `guacamole.yaml` to set parameter values.
 
 ## Requirements

--- a/plugins/module_utils/guacamole.py
+++ b/plugins/module_utils/guacamole.py
@@ -81,13 +81,15 @@ def guacamole_get_connections(base_url, validate_certs, datasource, group, auth_
 
 
     all_connections = []
-    if 'childConnections' in connections_group:
-        all_connections = connections_group['childConnections']
+    def fetch_child_connections(a_connections_group, depth=0):
+        for connection in a_connections_group:
+            all_connections.extend(connection.get('childConnections',[]))
+            if connection.get('childConnectionGroups') is not None:
+                fetch_child_connections(connection.get('childConnectionGroups'), depth = depth + 1)
+        if depth == 0:
+            return
 
-    if 'childConnectionGroups' in connections_group:
-        for group in connections_group['childConnectionGroups']:
-            if 'childConnections' in group:
-                all_connections = all_connections + group['childConnections']
+    fetch_child_connections([connections_group])
 
     return all_connections
 


### PR DESCRIPTION
Hi dear,

This **PR** comes in order to improve the connections listing module `scicore.guacamole.list_connections`.
Consider the screenshot below

![image](https://github.com/scicore-unibas-ch/ansible-modules-guacamole/assets/72862222/2051b6c6-8d83-43cd-9d18-8a645fa85da5)
In the current situation, the module will only list the connections:
- `digitalocean-almalinux`
- `vm1`
- `vm2`

**While leaving behind, the following connections**:
- `hv-ftp1`
- `hv-ftp2`
- `hv-web1`
- `hv-web2`

### Why ?

Because this block code in `module_utils/guacamole.py` just process at 2 nested levels. It just searches for child connections inside child connection groups.

https://github.com/scicore-unibas-ch/ansible-modules-guacamole/blob/316f23072fad7e31625163dd06190d38bfd10065/plugins/module_utils/guacamole.py#L83-L89

A recursive function is more suited to go down the rabbit hole and fetch all connections, no matter the nested level group depth. That's what this Pull Request does. It's also part of the solution to the issue #23 

Thanks !
