### PR TITLE
Grant user access to a connection in nested collection groups

### DIFF
--- a/plugins/module_utils/guacamole.py
+++ b/plugins/module_utils/guacamole.py
@@ -129,6 +129,29 @@ def guacamole_get_connections_group_id(base_url, validate_certs, datasource, gro
         return group_numeric_id
 
 
+def guacamole_get_connections_groups(base_url, validate_certs, datasource, auth_token):
+    """
+    Returns a dict of dicts.
+    Each dict provides the details for one of the connections groups defined in guacamole
+    """
+
+    url_list_connections_groups = URL_LIST_CONNECTIONS_GROUPS.format(
+        url=base_url, datasource=datasource, token=auth_token)
+
+    try:
+        connections_groups = json.load(open_url(url_list_connections_groups, method='GET',
+                                                validate_certs=validate_certs))
+    except ValueError as e:
+        raise GuacamoleError(
+            'API returned invalid JSON when trying to obtain connections groups from %s: %s'
+            % (url_list_connections_groups, str(e)))
+    except Exception as e:
+        raise GuacamoleError('Could not obtain connections groups from %s: %s'
+                             % (url_list_connections_groups, str(e)))
+
+    return connections_groups
+
+
 def guacamole_get_users(base_url, validate_certs, datasource, auth_token):
     """
     Returns a dict with all the users registered in the guacamole server

--- a/plugins/modules/guacamole_connections_group.py
+++ b/plugins/modules/guacamole_connections_group.py
@@ -9,7 +9,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 from ansible_collections.scicore.guacamole.plugins.module_utils.guacamole import GuacamoleError, \
-    guacamole_get_token, guacamole_get_connections, guacamole_get_connections_group_id
+    guacamole_get_token, guacamole_get_connections, guacamole_get_connections_group_id, guacamole_get_connections_groups
 __metaclass__ = type
 
 ANSIBLE_METADATA = {
@@ -149,33 +149,10 @@ message:
     returned: always
 '''
 
-URL_LIST_CONNECTIONS_GROUPS = "{url}/api/session/data/{datasource}/connectionGroups/?token={token}"
-URL_ADD_CONNECTIONS_GROUP = URL_LIST_CONNECTIONS_GROUPS
+URL_ADD_CONNECTIONS_GROUP = "{url}/api/session/data/{datasource}/connectionGroups/?token={token}"
 URL_UPDATE_CONNECTIONS_GROUP = "{url}/api/session/data/{datasource}/connectionGroups/{group_numeric_id}?token={token}"
 URL_DELETE_CONNECTIONS_GROUP = URL_UPDATE_CONNECTIONS_GROUP
 
-
-def guacamole_get_connections_groups(base_url, validate_certs, datasource, auth_token):
-    """
-    Returns a dict of dicts.
-    Each dict provides the details for one of the connections groups defined in guacamole
-    """
-
-    url_list_connections_groups = URL_LIST_CONNECTIONS_GROUPS.format(
-        url=base_url, datasource=datasource, token=auth_token)
-
-    try:
-        connections_groups = json.load(open_url(url_list_connections_groups, method='GET',
-                                                validate_certs=validate_certs))
-    except ValueError as e:
-        raise GuacamoleError(
-            'API returned invalid JSON when trying to obtain connections groups from %s: %s'
-            % (url_list_connections_groups, str(e)))
-    except Exception as e:
-        raise GuacamoleError('Could not obtain connections groups from %s: %s'
-                             % (url_list_connections_groups, str(e)))
-
-    return connections_groups
 
 
 def guacamole_populate_connections_group_payload(module_params):


### PR DESCRIPTION
Hi,

This PR comes in order to fix the issue reported there #23 
Since the issue is already well detailed by @fastlorenzo, I'm not going to repeat. To summarize, consider the architecture below:

![image](https://github.com/scicore-unibas-ch/ansible-modules-guacamole/assets/72862222/1388ace1-3041-46ed-a035-f015ea484093)

In the current situation, if we try to grant a user access to the connections `hv-ftp1` and `hv-ftp2`, the result will be as follows:

![image](https://github.com/scicore-unibas-ch/ansible-modules-guacamole/assets/72862222/e4579185-f14c-46b3-a015-b870c316b25d)

## Why?

Because this snippet code in `modules/guacamole_user.py` does NOT traverse the whole parent connections groups tree until ROOT:

https://github.com/scicore-unibas-ch/ansible-modules-guacamole/blob/010dcd4b0932f2810f1a530a2e6da3ac0f1eab3d/plugins/modules/guacamole_user.py#L524-L529


And it doesn't work because Guacamole requires granting access to all the parent connection groups of a child connection. 

## How to fix?

We need to replace the snippet code above, by the call of an inner recursive function as follows:

```python
        for conn in guacamole_connections:
            if conn['name'] in module.params['allowed_connections']:
                allowed_conn_ids.add(conn['identifier'])

                # If the connection is in a sub-group we need to grant access to the connection
                # and all the parent connection groups.

                # This an inner recursive function which will traverse the entire tree until ROOT
                # is reached in order to grant access to all necessary parent connection groups.
                def fetch_parent_grous_id(parentid):
                    if parentid != 'ROOT':
                        allowed_group_ids.add(parentid)
                        for group_id in guacamole_connections_groups:
                            if group_id == parentid:
                                fetch_parent_grous_id(guacamole_connections_groups[group_id]['parentIdentifier'])
                
                fetch_parent_grous_id(conn['parentIdentifier'])
```
We also need to move the `guacamole_get_connections_groups` function from `modules/guacamole_connections_group.py` to `module_utils/guacamole.py` because that function is also used now in `modules/guacamole_user.py`.

So with these changes, the PR will result into this:
 
![image](https://github.com/scicore-unibas-ch/ansible-modules-guacamole/assets/72862222/b80c1b34-1cca-4036-8eae-269506e92f9b)

That's all !