### PR TITLE
Add to possibility to configure guacd parameters

### DIFF
--- a/plugins/modules/guacamole_connection.py
+++ b/plugins/modules/guacamole_connection.py
@@ -69,6 +69,23 @@ options:
         aliases: ['parentIdentifier']
         type: str
 
+    guacd_hostname:
+        description:
+            - Hostname or ip of the guacd to connect
+        type: str
+
+    guacd_port:
+        description:
+            - Port to connect on guacd
+        type: int
+
+    guacd_encryption:
+        description:
+            - Connect with SSL / TLS or None (unencrypted)
+        type: str
+        choices:
+            - ssl
+            - ""
     protocol:
         description:
             - Protocol to use for the new connection
@@ -396,12 +413,12 @@ def guacamole_populate_connection_payload(module_params):
             "sftp-directory": module_params['sftp_default_upload_directory'],
         },
         "attributes": {
-            "guacd-encryption": "",
+            "guacd-encryption": module_params['guacd_encryption'],
             "failover-only": "",
             "weight": "",
             "max-connections": module_params['max_connections'],
-            "guacd-hostname": "",
-            "guacd-port": "",
+            "guacd-hostname": module_params['guacd_hostname'],
+            "guacd-port": module_params['guacd_port'],
             "max-connections-per-user": module_params['max_connections_per_user']
         }
     }
@@ -571,6 +588,9 @@ def main():
         disable_copy=dict(type='bool', default=False),
         disable_paste=dict(type='bool', default=False),
         cursor=dict(type='str', required=False),
+        guacd_hostname=dict(type='str', required=False),
+        guacd_port=dict(type='int', required=False),
+        guacd_encryption=dict(type='str', required=False),
     )
 
     result = dict(changed=False, msg='', diff={},


### PR DESCRIPTION
Added as not mandatory these args :
* guacd_hostname (not mandatory, string value)
* guacd_port (not mandatory, int)
* guacd_encryption (not mandatory, str, choices: [ "ssl", "" ]