### PR TITLE
feat(rdp): add admin console option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ OPTIONS (= is mandatory):
         (Choices: 8, 16, 24, 32)[Default: (null)]
         type: int
 
+- rdp_console  Sets session as admin
+        default: null
+        type: bool
+
 - rdp_domain
         Domain for the connection
         [Default: (null)]

--- a/plugins/modules/guacamole_connection.py
+++ b/plugins/modules/guacamole_connection.py
@@ -206,6 +206,11 @@ options:
             - Display height
         type: int
 
+    rdp_console:
+        description:
+            - Sets session as admin
+        type: bool
+
     ssh_passphrase:
         description:
             - Passphrase for the SSH private key
@@ -471,7 +476,8 @@ def guacamole_populate_connection_payload(module_params):
             "server_layout",
             "width",
             "height",
-            "resize_method"
+            "resize_method",
+            "console"
         )
         guacamole_add_parameter(payload, module_params, parameters, "rdp")
         if module_params.get('rdp_ignore_server_certs'):
@@ -583,6 +589,7 @@ def main():
         ),
         rdp_width=dict(type='int'),
         rdp_height=dict(type='int'),
+        rdp_console=dict(type='bool', default=False, required=False),
         state=dict(type='str', choices=['absent', 'present'], default='present'),
         max_connections=dict(type='int', required=False),
         max_connections_per_user=dict(type='int'),


### PR DESCRIPTION
Hello,

This code change adds the parameter `rdp_console`, allowing the user to set the RDP connection as an admin. This parameter expects a `bool` value.

Note that `console` is the parameter provided by the Guacamole project for setting an RDP session to an administrative one; thus, the name of this ansible module parameter is simply `rpd_console`.

Closes #49 