### PR TITLE
Add rdp_disable_gfx (new option of guacamole 1.6) option

### DIFF
--- a/plugins/modules/guacamole_connection.py
+++ b/plugins/modules/guacamole_connection.py
@@ -131,6 +131,11 @@ options:
         description:
             - Domain for the connection
 
+    rdp_disable_gfx:
+        description:
+            - Disable GFX acceleration
+        type: bool
+
     rdp_enable_drive:
         description:
             - Enable network drive mapping
@@ -482,6 +487,8 @@ def guacamole_populate_connection_payload(module_params):
         guacamole_add_parameter(payload, module_params, parameters, "rdp")
         if module_params.get('rdp_ignore_server_certs'):
             payload['parameters']['ignore-cert'] = module_params['rdp_ignore_server_certs']
+        if module_params.get('rdp_disable_gfx'):
+            payload['parameters']['disable-gfx'] = module_params['rdp_disable_gfx']
     elif module_params["protocol"] == "ssh":
         parameters = ("private_key", "passphrase")
         guacamole_add_parameter(payload, module_params, parameters, "ssh")
@@ -559,6 +566,7 @@ def main():
         password=dict(type='str', no_log=True),
         rdp_color_depth=dict(type='int', choices=(8, 16, 24, 32)),
         rdp_domain=dict(type='str'),
+        rdp_disable_gfx=dict(type='bool', default=False),
         rdp_enable_drive=dict(type='bool', default=False),
         rdp_drive_name=dict(type='str'),
         rdp_drive_path=dict(type='str'),


### PR DESCRIPTION
The new version of guacamole (1.6.0) introduce  some performance improvement, but one important of them can introduce issue on old OS : 

Version 1.6.0 of Guacamole introduces RDP support for the Graphics Pipeline Extension, or GFX, which is a way to encode remote display data that significantly accelerates the display of that data on the client, resulting in applications that are much more responsive on RDP clients. The GFX extension is enabled by default, as most common RDP servers support it, and a few actually require it. If, for some reason, you’re connecting to a server that does not support it, or you find it causing problems, this connection parameter allows you to disable support for it, falling back to the more basic implementation for sending graphics over RDP.

So it's really important to be able to disable it.
This PR add the possiblity to add rdp_disable_gfx option, it's a boolean and in the database is store as disable_gfx